### PR TITLE
fix(ci): remove auto git-push to main from benchmark workflows

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -106,13 +106,6 @@ jobs:
       - name: Aggregate results
         run: python scripts/aggregate_for_hf.py
 
-      - name: Commit and push hf_data
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add hf_data/
-          git diff --cached --quiet || (git commit -m "ci: benchmark results $(date -u +%Y-%m-%dT%H:%M:%SZ) [run ${{ github.run_id }}]" && git push)
-
       - name: Upload benchmark artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/upload-to-hf.yml
+++ b/.github/workflows/upload-to-hf.yml
@@ -1,15 +1,16 @@
 name: Upload to Hugging Face
 
-# 当 hf_data/ 下有 JSON 文件变动时自动触发
+# 当 hf_data/ 下有 JSON 文件变动时自动触发（仅 main-dev 分支）
 # 用户工作流：
 #   1. python scripts/aggregate_for_hf.py   （本地聚合）
-#   2. git add hf_data/ && git commit && git push  （触发此 workflow）
+#   2. git add hf_data/ && git commit && git push origin main-dev  （触发此 workflow）
 #   3. Actions 自动：并发安全合并 → 上传 HF → 清理 hf_data/
+#
+# 注意：main 分支不触发此 workflow，benchmark results 不应直接推送到 main。
 
 on:
   push:
     branches:
-      - main
       - main-dev
     paths:
       - "hf_data/**/*.json"

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-
 from sage.common.config.ports import SagePorts
 
 

--- a/experiments/base_experiment.py
+++ b/experiments/base_experiment.py
@@ -19,6 +19,7 @@ from importlib import metadata
 from pathlib import Path
 
 import numpy as np
+
 from experiments.common import RequestResult
 from experiments.common.component_versions import (
     collect_component_versions,

--- a/experiments/pipelines/pipeline_a_rag.py
+++ b/experiments/pipelines/pipeline_a_rag.py
@@ -186,7 +186,7 @@ class EmbeddingMapFunction(MapFunction):
         self.timeout = timeout
 
     def execute(self, data: dict) -> dict:
-        """执行 embedding""
+        """执行 embedding"""
         query = data["query"]
 
         with httpx.Client(timeout=self.timeout, proxy=None) as client:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,13 @@ packages = ["config", "experiments", "sage_benchmark"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+exclude = [
+    "src/",          # Untracked submodule / installed package content
+    ".venv/",
+    "venv/",
+    "build/",
+    "dist/",
+]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]

--- a/scripts/sage_bench_cli.py
+++ b/scripts/sage_bench_cli.py
@@ -4,12 +4,13 @@ from sage.common.config.ports import SagePorts
 
 _DEFAULT_GATEWAY_URL = f"http://localhost:{SagePorts.GATEWAY_DEFAULT}"
 
-from experiments.config import ExperimentConfig, WorkloadConfig
 from sage.benchmark.benchmark_sage.experiments.exp_5_1_e2e_pipeline import E2EPipelineExperiment
 from sage.benchmark.benchmark_sage.experiments.exp_5_2_control_plane import ControlPlaneExperiment
 from sage.benchmark.benchmark_sage.experiments.exp_5_3_isolation import IsolationExperiment
 from sage.benchmark.benchmark_sage.experiments.exp_5_4_scalability import ScalabilityExperiment
 from sage.benchmark.benchmark_sage.experiments.exp_5_5_heterogeneity import HeterogeneityExperiment
+
+from experiments.config import ExperimentConfig, WorkloadConfig
 
 
 def main():
@@ -29,9 +30,7 @@ def main():
     run_parser.add_argument("--rate", type=float, default=10.0, help="Request rate (req/s)")
     run_parser.add_argument("--count", type=int, default=100, help="Total requests")
     run_parser.add_argument("--llm-ratio", type=float, default=0.7, help="LLM ratio")
-    run_parser.add_argument(
-        "--gateway", type=str, default=_DEFAULT_GATEWAY_URL, help="Gateway URL"
-    )
+    run_parser.add_argument("--gateway", type=str, default=_DEFAULT_GATEWAY_URL, help="Gateway URL")
     run_parser.add_argument("--output", type=str, default="./outputs", help="Output directory")
 
     args = parser.parse_args()


### PR DESCRIPTION
## 问题

CI nightly benchmark 任务通过 `github-actions[bot]` 直接将 `benchmark_results.json` 提交推送到 `main` 分支，导致 `main-dev` 持续落后于 `main`。

## 修复内容

- **`ci-benchmarks.yml`**：删除 'Commit and push hf_data' 步骤，benchmark results 只存为 GitHub artifact 并上传到 HF Datasets，不再污染 git 历史。  
- **`upload-to-hf.yml`**：触发条件从 `[main, main-dev]` 改为只监听 `main-dev`，防止链式推送到 main。  
- **`pyproject.toml`**：ruff 排除 `src/` 目录（untracked 子模块内容），防止 pre-commit 误报。

## 影响

下次 nightly CI 运行后，main 分支不会再有自动 bot 提交。